### PR TITLE
Typo fix ai_boss25.lua

### DIFF
--- a/game/scripts/vscripts/ai/ai_boss25.lua
+++ b/game/scripts/vscripts/ai/ai_boss25.lua
@@ -42,7 +42,7 @@ function AIThink(thisEntity)
 				if not target:HasModifier("modifier_boss_wk_mortal_strike_debuff") then
 					return CastMortalStrike(target)
 				else
-					local newt = AICore:RandomEnemyHeroInRange( thisEntity, thisEntity.mortal:GetTrueCastRange() + thisEntity:GetIdealSpeed(), false )
+					local newT = AICore:RandomEnemyHeroInRange( thisEntity, thisEntity.mortal:GetTrueCastRange() + thisEntity:GetIdealSpeed(), false )
 					if newT and not newT:HasModifier("modifier_boss_wk_mortal_strike_debuff") then
 						return CastMortalStrike(newT)
 					end


### PR DESCRIPTION
If the priority target already has mortal strike debuff, the boss would never try a random hero in range since `newt` was lowercase.